### PR TITLE
Run acceptance test using the most recent service version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,13 +49,13 @@ jobs:
           command: cat /dev/null | sbt it:test
 
       - run:
-          name: Acceptance tests
-          command: |
-            ./start-local.sh
-            sbt "acceptance/test"
-
-      - run:
           name: Push service docker image
           command: |
             echo $DOCKER_PWD | docker login -u $DOCKER_LOGIN --password-stdin
             sbt "service/docker:publish"
+
+      - run:
+          name: Acceptance tests
+          command: |
+            ./start-local.sh
+            sbt "acceptance/test"


### PR DESCRIPTION
Note that this is a simplistic setup that suffices for a single or less than a handful developer working with the codebase.

Acceptance test will use the `latest` published dockerised service version. 

To avoid risk of concurrent builds interfering with one another, we could define the service version we will be testing explicitly instead of `latest` (i.e. the name of the branch).