### PR TITLE
Feat: Refine DynamicConfig Algebra to Support Flexible Backend Implementations

### DIFF
--- a/auth/src/main/scala/org/fiume/sketch/auth/JwtIssuer.scala
+++ b/auth/src/main/scala/org/fiume/sketch/auth/JwtIssuer.scala
@@ -50,14 +50,14 @@ private[auth] object JwtIssuer:
       case e: Throwable                  => JwtUnknownError(e.getMessage)
 
   // see https://www.iana.org/assignments/jwt/jwt.xhtml
-  private case class Content(preferredUsername: Username)
+  private case class Content(preferredUsername: Username) extends AnyVal
 
   private object Content:
     given Encoder[Content] with
-      final def apply(a: Content): Json = Json.obj(
+      override def apply(a: Content): Json = Json.obj(
         "preferred_username" -> a.preferredUsername.value.asJson
       )
 
     given Decoder[Content] with
-      final def apply(c: HCursor): Decoder.Result[Content] =
+      override def apply(c: HCursor): Decoder.Result[Content] =
         c.downField("preferred_username").as[String].map(value => Content(Username.makeUnsafeFromString(value)))

--- a/auth/src/main/scala/org/fiume/sketch/auth/accounts/jobs/ScheduledAccountDeletionJob.scala
+++ b/auth/src/main/scala/org/fiume/sketch/auth/accounts/jobs/ScheduledAccountDeletionJob.scala
@@ -5,6 +5,7 @@ import cats.effect.Sync
 import cats.implicits.*
 import org.fiume.sketch.auth.accounts.jobs.ScheduledAccountDeletionJob.JobReport
 import org.fiume.sketch.auth.config.Dynamic.RecipientsKey
+import org.fiume.sketch.auth.config.Dynamic.given
 import org.fiume.sketch.shared.auth.UserId
 import org.fiume.sketch.shared.auth.accounts.{AccountDeletedNotificationProducer, AccountDeletionEventConsumer}
 import org.fiume.sketch.shared.auth.accounts.AccountDeletedNotification.{Notified, ToNotify}

--- a/auth/src/main/scala/org/fiume/sketch/auth/config/Dynamic.scala
+++ b/auth/src/main/scala/org/fiume/sketch/auth/config/Dynamic.scala
@@ -1,7 +1,15 @@
 package org.fiume.sketch.auth.config
 
+import io.circe.{Decoder, Encoder}
 import org.fiume.sketch.shared.common.config.DynamicConfig
 import org.fiume.sketch.shared.common.events.Recipient
+import org.fiume.sketch.shared.common.typeclasses.AsString
 
 object Dynamic:
   case object RecipientsKey extends DynamicConfig.Key[Set[Recipient]]
+
+  given AsString[RecipientsKey.type] with
+    extension (key: RecipientsKey.type) override def asString() = "account.deletion.notification.recipients"
+
+  given Decoder[Recipient] = Decoder.decodeString.map(Recipient(_))
+  given Encoder[Recipient] = Encoder.encodeString.contramap(_.name)

--- a/build.sbt
+++ b/build.sbt
@@ -184,6 +184,7 @@ lazy val sharedComponents =
         Dependency.cats,
         Dependency.circeCore,
         Dependency.circeGeneric,
+        Dependency.circeParser,
         Dependency.http4sCirce,
         Dependency.http4sDsl,
         Dependency.log4catsSlf4j,

--- a/docs/TODOs.md
+++ b/docs/TODOs.md
@@ -5,22 +5,7 @@
 
 1) Clean up all entities upon permanent deletion
 
-- Config recipients of deletion notifications dynamically
-  - Define algebra and simple in-memory implementation of getRecipients config
-  - Update the deletion job and test
-  - Refactor config Api and impl to clearly distinguish between dynamic and env vars configs
-  - Implement an implementation for dynamic config based on Postgres
-
 - Services (e.g. sketch) deletes user data upon accound deletion
-
-For the table....
-
-```
-Indexing: Add a GIN index on the config_value column for faster querying within JSONB structures:
-
-CREATE INDEX idx_configs_value ON configs USING gin (config_value);
-```
-
 
 
 ### Others

--- a/service/src/main/scala/org/fiume/sketch/app/App.scala
+++ b/service/src/main/scala/org/fiume/sketch/app/App.scala
@@ -28,7 +28,7 @@ object App:
 
     val serviceStream = for
       staticConfig <- AppConfig.makeFromEnvs[F]().toResource
-      dynamicConfig <- AppConfig.makeDynamicConfig[F, ConnectionIO]().toResource
+      dynamicConfig <- AppConfig.makeDynamicConfig[F]()
       comps <- AppComponents.make(staticConfig)
       httpServiceStream = {
         val server = httpServer[F](staticConfig, comps)

--- a/service/src/main/scala/org/fiume/sketch/app/AppConfig.scala
+++ b/service/src/main/scala/org/fiume/sketch/app/AppConfig.scala
@@ -6,6 +6,7 @@ import ciris.*
 import com.comcast.ip4s.*
 import org.fiume.sketch.auth.KeyStringifier
 import org.fiume.sketch.auth.config.Dynamic.RecipientsKey
+import org.fiume.sketch.auth.config.Dynamic.given
 import org.fiume.sketch.rustic.RusticClientConfig
 import org.fiume.sketch.shared.auth.accounts.AccountConfig
 import org.fiume.sketch.shared.common.app.Version.Environment
@@ -73,8 +74,9 @@ object AppConfig:
     )).load[F]
 
   def makeDynamicConfig[F[_]: Sync, Txn[_]: Sync](): F[DynamicConfig[Txn]] =
-    InMemoryDynamicConfig.make[F, Txn](
-      state = Map(RecipientsKey -> Set(Recipient("sketch")))
+    InMemoryDynamicConfig.makeWithKvPair[F, Txn, RecipientsKey.type, Set[Recipient]](
+      key = RecipientsKey,
+      value = Set(Recipient("sketch"))
     )
 
   given ConfigDecoder[String, Environment] = ConfigDecoder[String].map(Environment.apply)

--- a/shared-components/src/main/scala/org/fiume/sketch/shared/common/config/DynamicConfig.scala
+++ b/shared-components/src/main/scala/org/fiume/sketch/shared/common/config/DynamicConfig.scala
@@ -2,7 +2,11 @@ package org.fiume.sketch.shared.common.config
 
 import cats.effect.{Ref, Sync}
 import cats.implicits.*
+import io.circe.{Decoder, Encoder, Json}
+import io.circe.parser.decode
+import io.circe.syntax.*
 import org.fiume.sketch.shared.common.config.DynamicConfig.Key
+import org.fiume.sketch.shared.common.typeclasses.AsString
 
 object DynamicConfig:
   trait Key[V]
@@ -11,17 +15,22 @@ object DynamicConfig:
  * An experiemental highly general algebra for fetching dynamic configurations.
  */
 trait DynamicConfig[F[_]]:
-  def getConfig[V](key: Key[V]): F[Option[V]]
+  def getConfig[K <: Key[V], V](key: K)(using AsString[K], Decoder[V]): F[Option[V]]
 
 /*
  * A thread-safe concurrent in-memory version of `DynamicConfig`.
  */
 object InMemoryDynamicConfig:
-  def make[F[_]: Sync, Txn[_]: Sync](state: Map[Key[?], Any]): F[DynamicConfig[Txn]] =
-    Ref.in[F, Txn, Map[Key[?], Any]](state).map { storage =>
+  def makeWithKvPair[F[_]: Sync, Txn[_]: Sync, K <: Key[V], V](key: K, value: V)(using AsString[K], Encoder[V]) =
+    make[F, Txn](Map(key.asString() -> value.asJson))
+
+  def make[F[_]: Sync, Txn[_]: Sync](state: Map[String, Json]): F[DynamicConfig[Txn]] =
+    Ref.in[F, Txn, Map[String, Json]](state).map { storage =>
       new DynamicConfig[Txn]():
-        // There's a limitation on this implementation with the assumption that the caller knows
-        // the type of value `V` of a given key `K`. A `ClassCastExpetion will be thrown at runtime in case of a mistake.
-        override def getConfig[V](key: Key[V]): Txn[Option[V]] =
-          storage.get.map(_.get(key).asInstanceOf[Option[V]])
+        override def getConfig[K <: Key[V], V](key: K)(using AsString[K], Decoder[V]): Txn[Option[V]] =
+          storage.get.map {
+            // TODO Refine error handling
+            // Add note on why sticking with `Option` and not returning `Either`
+            _.get(key.asString()).map(_.noSpaces).map(decode[V](_).toOption.get)
+          }
     }

--- a/shared-components/src/main/scala/org/fiume/sketch/shared/common/config/Namespace.scala
+++ b/shared-components/src/main/scala/org/fiume/sketch/shared/common/config/Namespace.scala
@@ -1,0 +1,3 @@
+package org.fiume.sketch.shared.common.config
+
+final case class Namespace(value: String) extends AnyVal

--- a/storage/src/it/scala/org/fiume/sketch/storage/auth/postgres/PostgresAccountDeletedNotificationsStoreSpec.scala
+++ b/storage/src/it/scala/org/fiume/sketch/storage/auth/postgres/PostgresAccountDeletedNotificationsStoreSpec.scala
@@ -12,13 +12,12 @@ import org.fiume.sketch.shared.common.events.{EventId, Recipient}
 import org.fiume.sketch.shared.testkit.ClockContext
 import org.fiume.sketch.shared.testkit.syntax.OptionSyntax.*
 import org.fiume.sketch.storage.testkit.DockerPostgresSuite
-import org.scalacheck.{Gen, ShrinkLowPriority}
+import org.scalacheck.Gen
 
 class PostgresAccountDeletedNotificationsStoreSpec
     extends CatsEffectSuite
     with ClockContext
-    with PostgresAccountDeletedNotificationStoreSpecContext
-    with ShrinkLowPriority:
+    with PostgresAccountDeletedNotificationStoreSpecContext:
 
   // Notes
 

--- a/storage/src/it/scala/org/fiume/sketch/storage/config/postgres/PostgresDynamicConfigStoreSpec.scala
+++ b/storage/src/it/scala/org/fiume/sketch/storage/config/postgres/PostgresDynamicConfigStoreSpec.scala
@@ -32,7 +32,7 @@ class PostgresDynamicConfigStoreSpec extends CatsEffectSuite with PostgresDynami
       }
     }
 
-  // TODO Check constraints?
+  // TODO Check constraints
 
 object PostgresDynamicConfigStoreSpecContext:
   case object SampleKey extends DynamicConfig.Key[Set[SampleValue]]

--- a/storage/src/it/scala/org/fiume/sketch/storage/config/postgres/PostgresDynamicConfigStoreSpec.scala
+++ b/storage/src/it/scala/org/fiume/sketch/storage/config/postgres/PostgresDynamicConfigStoreSpec.scala
@@ -9,7 +9,7 @@ import io.circe.{Decoder, Encoder}
 import io.circe.syntax.*
 import munit.CatsEffectSuite
 import org.fiume.sketch.shared.common.config.{DynamicConfig, Namespace}
-import org.fiume.sketch.shared.common.typeclasses.{AsString, FromString}
+import org.fiume.sketch.shared.common.typeclasses.AsString
 import org.fiume.sketch.shared.testkit.syntax.OptionSyntax.*
 import org.fiume.sketch.storage.config.postgres.DatabaseCodecs.given
 import org.fiume.sketch.storage.config.postgres.PostgresDynamicConfigStoreSpecContext.*
@@ -43,10 +43,6 @@ object PostgresDynamicConfigStoreSpecContext:
 
   given AsString[SampleKey.type] with
     extension (key: SampleKey.type) override def asString() = "sample.key"
-
-  type Error = String
-  given FromString[Error, SampleKey.type] with
-    extension (key: String) override def parsed() = Either.cond(key == "sample.key", SampleKey, "unknown key")
 
 trait PostgresDynamicConfigStoreSpecContext extends DockerPostgresSuite:
   def cleanStorage: ConnectionIO[Unit] = sql"TRUNCATE TABLE system.dynamic_configs".update.run.void

--- a/storage/src/it/scala/org/fiume/sketch/storage/config/postgres/PostgresDynamicConfigStoreSpec.scala
+++ b/storage/src/it/scala/org/fiume/sketch/storage/config/postgres/PostgresDynamicConfigStoreSpec.scala
@@ -26,7 +26,7 @@ class PostgresDynamicConfigStoreSpec extends CatsEffectSuite with PostgresDynami
         for
           _ <- givenConfig(namespace, SampleKey, value).ccommit
 
-          result <- provider.getConfig2(SampleKey).map(_.someOrFail).ccommit
+          result <- provider.getConfig(SampleKey).map(_.someOrFail).ccommit
 //
         yield assertEquals(result, value)
       }
@@ -40,11 +40,11 @@ object PostgresDynamicConfigStoreSpecContext:
   given Decoder[SampleValue] = Decoder.decodeString.map(SampleValue(_))
 
   given AsString[SampleKey.type] with
-    extension (key: SampleKey.type) override def asString() = "SampleKey"
+    extension (key: SampleKey.type) override def asString() = "sample.key"
 
   type Error = String
   given FromString[Error, SampleKey.type] with
-    extension (key: String) override def parsed() = Either.cond(key == "SampleKey", SampleKey, "unknown key")
+    extension (key: String) override def parsed() = Either.cond(key == "sample.key", SampleKey, "unknown key")
 
 trait PostgresDynamicConfigStoreSpecContext extends DockerPostgresSuite:
   def cleanStorage: ConnectionIO[Unit] = sql"TRUNCATE TABLE system.dynamic_configs".update.run.void

--- a/storage/src/it/scala/org/fiume/sketch/storage/config/postgres/PostgresDynamicConfigStoreSpec.scala
+++ b/storage/src/it/scala/org/fiume/sketch/storage/config/postgres/PostgresDynamicConfigStoreSpec.scala
@@ -32,6 +32,8 @@ class PostgresDynamicConfigStoreSpec extends CatsEffectSuite with PostgresDynami
       }
     }
 
+  // TODO Check constraints?
+
 object PostgresDynamicConfigStoreSpecContext:
   case object SampleKey extends DynamicConfig.Key[Set[SampleValue]]
   case class SampleValue(value: String) extends AnyVal

--- a/storage/src/it/scala/org/fiume/sketch/storage/config/postgres/PostgresDynamicConfigStoreSpec.scala
+++ b/storage/src/it/scala/org/fiume/sketch/storage/config/postgres/PostgresDynamicConfigStoreSpec.scala
@@ -1,0 +1,66 @@
+package org.fiume.sketch.storage.config.postgres
+
+import cats.effect.IO
+import cats.implicits.*
+import doobie.ConnectionIO
+import doobie.implicits.*
+import doobie.util.Write
+import io.circe.{Decoder, Encoder}
+import io.circe.syntax.*
+import munit.CatsEffectSuite
+import org.fiume.sketch.shared.common.config.{DynamicConfig, Namespace}
+import org.fiume.sketch.shared.common.typeclasses.{AsString, FromString}
+import org.fiume.sketch.shared.testkit.syntax.OptionSyntax.*
+import org.fiume.sketch.storage.config.postgres.DatabaseCodecs.given
+import org.fiume.sketch.storage.config.postgres.PostgresDynamicConfigStoreSpecContext.*
+import org.fiume.sketch.storage.config.postgres.PostgresDynamicConfigStoreSpecContext.given
+import org.fiume.sketch.storage.testkit.DockerPostgresSuite
+
+class PostgresDynamicConfigStoreSpec extends CatsEffectSuite with PostgresDynamicConfigStoreSpecContext:
+
+  test("retrieves dynamic configuration from a Postgres provider"):
+    will(cleanStorage) {
+      val namespace = Namespace("it-test")
+      val value = Set(SampleValue("change-me-at-runtime"))
+      PostgresDynamicConfigStore.makeForNamespace[IO](namespace).use { case provider =>
+        for
+          _ <- givenConfig(namespace, SampleKey, value).ccommit
+
+          result <- provider.getConfig2(SampleKey).map(_.someOrFail).ccommit
+//
+        yield assertEquals(result, value)
+      }
+    }
+
+object PostgresDynamicConfigStoreSpecContext:
+  case object SampleKey extends DynamicConfig.Key[Set[SampleValue]]
+  case class SampleValue(value: String) extends AnyVal
+
+  given Encoder[SampleValue] = Encoder.encodeString.contramap(_.value)
+  given Decoder[SampleValue] = Decoder.decodeString.map(SampleValue(_))
+
+  given AsString[SampleKey.type] with
+    extension (key: SampleKey.type) override def asString() = "SampleKey"
+
+  type Error = String
+  given FromString[Error, SampleKey.type] with
+    extension (key: String) override def parsed() = Either.cond(key == "SampleKey", SampleKey, "unknown key")
+
+trait PostgresDynamicConfigStoreSpecContext extends DockerPostgresSuite:
+  def cleanStorage: ConnectionIO[Unit] = sql"TRUNCATE TABLE system.dynamic_configs".update.run.void
+
+  def givenConfig[K <: DynamicConfig.Key[V], V](namespace: Namespace, key: K, value: V)(using
+    AsString[K],
+    Encoder[V]
+  ): ConnectionIO[Unit] =
+    sql"""
+         |INSERT INTO system.dynamic_configs (
+         |  namespace,
+         |  key,
+         |  value
+         |) VALUES (
+         |  $namespace,
+         |  ${key.asString()},
+         |  ${value.asJson}
+         |)
+    """.stripMargin.update.run.void

--- a/storage/src/main/resources/db/migration/V1__Create_Auth_Tables.sql
+++ b/storage/src/main/resources/db/migration/V1__Create_Auth_Tables.sql
@@ -21,6 +21,11 @@ CREATE TABLE system.dynamic_configs (
   PRIMARY KEY (namespace, key)
 );
 
+INSERT INTO system.dynamic_configs (namespace, key, value)
+VALUES(
+  'sketch', 'account.deletion.notification.recipients', '["sketch-projects"]'::jsonb
+);
+
 CREATE SCHEMA auth;
 
 CREATE TABLE auth.users (

--- a/storage/src/main/resources/db/migration/V1__Create_Auth_Tables.sql
+++ b/storage/src/main/resources/db/migration/V1__Create_Auth_Tables.sql
@@ -13,9 +13,9 @@ $$ LANGUAGE plpgsql;
 CREATE SCHEMA system; -- an alternative name could be 'core'
 
 CREATE TABLE system.dynamic_configs (
-  namespace TEXT NOT NULL,                                                  -- logically groups configs for different services or modules
-  key TEXT NOT NULL CHECk (length(key) <= 255 AND key ~ '^[a-zA-Z0-9_]+$'),
-  value JSONB NOT NULL,                                                     -- Stores scalar (e.g. strings, booleans) or structured data (e.g. arrays), offering flexibility for diverse config values
+  namespace TEXT NOT NULL,                                                      -- logically groups configs for different services or modules
+  key TEXT NOT NULL CHECk (length(key) <= 255 AND key ~ '^[a-zA-Z0-9_.]+$'),
+  value JSONB NOT NULL,                                                         -- Stores scalar (e.g. strings, booleans) or structured data (e.g. arrays), offering flexibility for diverse config values
   created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
   updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
   PRIMARY KEY (namespace, key)

--- a/storage/src/main/resources/db/migration/V1__Create_Auth_Tables.sql
+++ b/storage/src/main/resources/db/migration/V1__Create_Auth_Tables.sql
@@ -10,7 +10,7 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;
 
-CREATE SCHEMA system; -- an alternative name could be 'core'
+CREATE SCHEMA system;
 
 CREATE TABLE system.dynamic_configs (
   namespace TEXT NOT NULL,                                                      -- logically groups configs for different services or modules

--- a/storage/src/main/scala/org/fiume/sketch/storage/auth/postgres/PostgresAccountDeletedNotificationsStore.scala
+++ b/storage/src/main/scala/org/fiume/sketch/storage/auth/postgres/PostgresAccountDeletedNotificationsStore.scala
@@ -1,6 +1,6 @@
 package org.fiume.sketch.storage.auth.postgres
 
-import cats.effect.{Async, Resource}
+import cats.effect.{Resource, Sync}
 import doobie.*
 import doobie.free.connection.ConnectionIO
 import doobie.implicits.*
@@ -14,10 +14,10 @@ import org.fiume.sketch.shared.common.events.Recipient
 import org.fiume.sketch.storage.auth.postgres.DatabaseCodecs.given
 
 object PostgresAccountDeletedNotificationsStore:
-  def makeProducer[F[_]: Async](): Resource[F, AccountDeletedNotificationProducer[ConnectionIO]] =
+  def makeProducer[F[_]: Sync](): Resource[F, AccountDeletedNotificationProducer[ConnectionIO]] =
     Resource.pure(new PostgresAccountDeletedNotificationProducerStore())
 
-  def makeConsumer[F[_]: Async](recipient: Recipient): Resource[F, AccountDeletedNotificationConsumer[ConnectionIO]] =
+  def makeConsumer[F[_]: Sync](recipient: Recipient): Resource[F, AccountDeletedNotificationConsumer[ConnectionIO]] =
     Resource.pure(new PostgresAccountDeletedNotificationConsumerStore(recipient))
 
 private class PostgresAccountDeletedNotificationProducerStore() extends AccountDeletedNotificationProducer[ConnectionIO]:

--- a/storage/src/main/scala/org/fiume/sketch/storage/auth/postgres/PostgresAccountDeletionEventsStore.scala
+++ b/storage/src/main/scala/org/fiume/sketch/storage/auth/postgres/PostgresAccountDeletionEventsStore.scala
@@ -1,6 +1,6 @@
 package org.fiume.sketch.storage.auth.postgres
 
-import cats.effect.{Async, Resource}
+import cats.effect.{Resource, Sync}
 import cats.implicits.*
 import doobie.*
 import doobie.free.connection.ConnectionIO
@@ -16,7 +16,7 @@ import org.fiume.sketch.shared.auth.accounts.AccountDeletionEvent.{Scheduled, To
 import org.fiume.sketch.storage.auth.postgres.DatabaseCodecs.given
 
 object PostgresAccountDeletionEventsStore:
-  def make[F[_]: Async]()
+  def make[F[_]: Sync]()
     : Resource[F, CancellableAccountDeletionEventProducer[ConnectionIO] & AccountDeletionEventConsumer[ConnectionIO]] =
     Resource.pure(new PostgresAccountDeletionEventsStore())
 

--- a/storage/src/main/scala/org/fiume/sketch/storage/config/postgres/DatabaseCodecs.scala
+++ b/storage/src/main/scala/org/fiume/sketch/storage/config/postgres/DatabaseCodecs.scala
@@ -1,0 +1,29 @@
+package org.fiume.sketch.storage.config.postgres
+
+import cats.implicits.*
+import doobie.util.meta.Meta
+import io.circe.Json
+import org.fiume.sketch.shared.common.config.{DynamicConfig, Namespace}
+import org.fiume.sketch.shared.common.typeclasses.{AsString, FromString}
+import org.postgresql.util.PGobject
+
+private[storage] object DatabaseCodecs:
+
+  given Meta[Namespace] = Meta[String].timap(Namespace(_))(_.value)
+
+  type Error = String
+  given [V](using
+    ts: AsString[DynamicConfig.Key[V]],
+    fs: FromString[Error, DynamicConfig.Key[V]]
+  ): Meta[DynamicConfig.Key[V]] = Meta[String].tiemap(_.parsed())(_.asString())
+
+  // TODO Move it to a common place
+  given Meta[Json] =
+    Meta.Advanced
+      .other[PGobject]("json")
+      .timap[Json](a => io.circe.parser.parse(a.getValue).leftMap[Json](e => throw e).merge)(a =>
+        val o = new PGobject
+        o.setType("json")
+        o.setValue(a.noSpaces)
+        o
+      )

--- a/storage/src/main/scala/org/fiume/sketch/storage/config/postgres/DatabaseCodecs.scala
+++ b/storage/src/main/scala/org/fiume/sketch/storage/config/postgres/DatabaseCodecs.scala
@@ -3,19 +3,12 @@ package org.fiume.sketch.storage.config.postgres
 import cats.implicits.*
 import doobie.util.meta.Meta
 import io.circe.Json
-import org.fiume.sketch.shared.common.config.{DynamicConfig, Namespace}
-import org.fiume.sketch.shared.common.typeclasses.{AsString, FromString}
+import org.fiume.sketch.shared.common.config.Namespace
 import org.postgresql.util.PGobject
 
 private[storage] object DatabaseCodecs:
 
   given Meta[Namespace] = Meta[String].timap(Namespace(_))(_.value)
-
-  type Error = String
-  given [V](using
-    ts: AsString[DynamicConfig.Key[V]],
-    fs: FromString[Error, DynamicConfig.Key[V]]
-  ): Meta[DynamicConfig.Key[V]] = Meta[String].tiemap(_.parsed())(_.asString())
 
   // TODO Move it to a common place
   given Meta[Json] =

--- a/storage/src/main/scala/org/fiume/sketch/storage/config/postgres/PostgresDynamicConfigStore.scala
+++ b/storage/src/main/scala/org/fiume/sketch/storage/config/postgres/PostgresDynamicConfigStore.scala
@@ -12,16 +12,12 @@ import org.fiume.sketch.shared.common.typeclasses.AsString
 import org.fiume.sketch.storage.config.postgres.DatabaseCodecs.given
 
 object PostgresDynamicConfigStore:
-  def makeForNamespace[F[_]: Async](
-    namespace: Namespace
-  ): Resource[F, PostgresDynamicConfigStore] = // TODO Change it to return DynamicConfig[ConnectionIO]
+  def makeForNamespace[F[_]: Async](namespace: Namespace): Resource[F, PostgresDynamicConfigStore] =
     Resource.pure(new PostgresDynamicConfigStore(namespace))
 
 private class PostgresDynamicConfigStore private (namespace: Namespace) extends DynamicConfig[ConnectionIO]:
 
-  override def getConfig[V](key: Key[V]): ConnectionIO[Option[V]] = ???
-
-  def getConfig2[K <: Key[V], V](key: K)(using fs: AsString[K], d: Decoder[V]): ConnectionIO[Option[V]] =
+  override def getConfig[K <: Key[V], V](key: K)(using AsString[K], Decoder[V]): ConnectionIO[Option[V]] =
     Statements.selectConfig(namespace, key).option
 
 private object Statements:

--- a/storage/src/main/scala/org/fiume/sketch/storage/config/postgres/PostgresDynamicConfigStore.scala
+++ b/storage/src/main/scala/org/fiume/sketch/storage/config/postgres/PostgresDynamicConfigStore.scala
@@ -1,0 +1,38 @@
+package org.fiume.sketch.storage.config.postgres
+
+import cats.effect.{Async, Resource}
+import doobie.free.connection.ConnectionIO
+import doobie.implicits.*
+import doobie.util.query.Query0
+import io.circe.{Decoder, Json}
+import io.circe.parser.decode
+import org.fiume.sketch.shared.common.config.{DynamicConfig, Namespace}
+import org.fiume.sketch.shared.common.config.DynamicConfig.Key
+import org.fiume.sketch.shared.common.typeclasses.AsString
+import org.fiume.sketch.storage.config.postgres.DatabaseCodecs.given
+
+object PostgresDynamicConfigStore:
+  def makeForNamespace[F[_]: Async](
+    namespace: Namespace
+  ): Resource[F, PostgresDynamicConfigStore] = // TODO Change it to return DynamicConfig[ConnectionIO]
+    Resource.pure(new PostgresDynamicConfigStore(namespace))
+
+private class PostgresDynamicConfigStore private (namespace: Namespace) extends DynamicConfig[ConnectionIO]:
+
+  override def getConfig[V](key: Key[V]): ConnectionIO[Option[V]] = ???
+
+  def getConfig2[K <: Key[V], V](key: K)(using fs: AsString[K], d: Decoder[V]): ConnectionIO[Option[V]] =
+    Statements.selectConfig(namespace, key).option
+
+private object Statements:
+  def selectConfig[K <: Key[V], V](namespace: Namespace, key: K)(using AsString[K], Decoder[V]): Query0[V] =
+    sql"""
+         |SELECT
+         |  value
+         |FROM system.dynamic_configs
+         |WHERE namespace = ${namespace} AND key = ${key.asString()}
+    """.stripMargin
+      .query[Json]
+      .map { json =>
+        decode[V](json.noSpaces).toOption.getOrElse(throw new IllegalStateException(s"unparsable json: $json"))
+      }

--- a/storage/src/main/scala/org/fiume/sketch/storage/config/postgres/PostgresDynamicConfigStore.scala
+++ b/storage/src/main/scala/org/fiume/sketch/storage/config/postgres/PostgresDynamicConfigStore.scala
@@ -30,5 +30,9 @@ private object Statements:
     """.stripMargin
       .query[Json]
       .map { json =>
-        decode[V](json.noSpaces).toOption.getOrElse(throw new IllegalStateException(s"unparsable json: $json"))
+        decode[V](json.noSpaces).toOption.getOrElse(throw new IllegalStateException(s"failed to parse input as JSON: $json"))
       }
+
+  // Note: Why throw an exception instead of returning `Either` instead of `Option`, for example?
+  // A failure to parse 'value' as JSON is an irrecoverable error caused by an illegal state.
+  // This is considered a bug, and to simplify various algebras, bugs in this project are handled via exceptions.

--- a/storage/src/main/scala/org/fiume/sketch/storage/config/postgres/PostgresDynamicConfigStore.scala
+++ b/storage/src/main/scala/org/fiume/sketch/storage/config/postgres/PostgresDynamicConfigStore.scala
@@ -1,6 +1,6 @@
 package org.fiume.sketch.storage.config.postgres
 
-import cats.effect.{Async, Resource}
+import cats.effect.{Resource, Sync}
 import doobie.free.connection.ConnectionIO
 import doobie.implicits.*
 import doobie.util.query.Query0
@@ -12,7 +12,7 @@ import org.fiume.sketch.shared.common.typeclasses.AsString
 import org.fiume.sketch.storage.config.postgres.DatabaseCodecs.given
 
 object PostgresDynamicConfigStore:
-  def makeForNamespace[F[_]: Async](namespace: Namespace): Resource[F, PostgresDynamicConfigStore] =
+  def makeForNamespace[F[_]: Sync](namespace: Namespace): Resource[F, DynamicConfig[ConnectionIO]] =
     Resource.pure(new PostgresDynamicConfigStore(namespace))
 
 private class PostgresDynamicConfigStore private (namespace: Namespace) extends DynamicConfig[ConnectionIO]:

--- a/storage/src/main/scala/org/fiume/sketch/storage/postgres/AbstractPostgresStore.scala
+++ b/storage/src/main/scala/org/fiume/sketch/storage/postgres/AbstractPostgresStore.scala
@@ -1,13 +1,13 @@
 package org.fiume.sketch.storage.postgres
 
-import cats.effect.Async
+import cats.effect.Sync
 import cats.~>
 import doobie.ConnectionIO
 import doobie.implicits.*
 import doobie.util.transactor.Transactor
 import org.fiume.sketch.shared.common.app.Store
 
-abstract class AbstractPostgresStore[F[_]: Async] protected (l: F ~> ConnectionIO, tx: Transactor[F])
+abstract class AbstractPostgresStore[F[_]: Sync] protected (l: F ~> ConnectionIO, tx: Transactor[F])
     extends Store[F, ConnectionIO]:
 
   override val lift: [A] => F[A] => ConnectionIO[A] = [A] => (fa: F[A]) => l(fa)


### PR DESCRIPTION
Notice how the implementation of `InMemoryDynamicConfig` has been drastically improved with [the enhanced algebra](https://github.com/rafaelfiume/sketch/pull/227/commits/667cfb576e9ce9aab8f919fbd577c35ba9573ac3) with the elimination of the unsafe `instanceOf` cast:

From:
```
      . . .
      new DynamicConfig[Txn]():
        // There's a limitation on this implementation with the assumption that the caller knows
        // the type of value `V` of a given key `K`. A `ClassCastExpetion will be thrown at runtime in case of a mistake.
        override def getConfig[V](key: Key[V]): Txn[Option[V]] =
          storage.get.map(_.get(key).asInstanceOf[Option[V]])
    }
```

To:
```
     . . .
      new DynamicConfig[Txn]():
        override def getConfig[K <: Key[V], V](key: K)(using AsString[K], Decoder[V]): Txn[Option[V]] =
          storage.get.map {
            _.get(key.asString()).map(_.noSpaces).map { json =>
              decode[V](json).toOption.getOrElse(throw new IllegalStateException(s"failed to parse input as JSON: $json"))
            }
          }

        // Note: see `PostgresDynamicConfigStore` for the rationale behind throwing an exception
        // when the expected JSON is unparsable.
    }
```

This PR introduces a [Postgres-based implementation of DynamicConfig algebra](https://github.com/rafaelfiume/sketch/pull/227/commits/68f0e36b8bef018f032a2ab8838dd54dc6734bf7), which is now [the one used in the app](https://github.com/rafaelfiume/sketch/pull/227/commits/b0c1a60db5f68f4ffc5435e786d50efbce13849c).